### PR TITLE
Bugfix for incorrect handshake location.

### DIFF
--- a/fluxion.sh
+++ b/fluxion.sh
@@ -925,7 +925,7 @@ function askauth {
 }
 
 function handshakelocation {
-
+	handshakeloc=""
         conditional_clear
 
         top


### PR DESCRIPTION
When typed incorrect handshake location, function "handshakelocation" loops in to cycle. Clearing "handshakeloc" variable breaks that loop.