### PR TITLE
Revert "Fixed lib path"

### DIFF
--- a/scripts/diagnostics.sh
+++ b/scripts/diagnostics.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source ../lib/InterfaceUtils.sh
+source lib/InterfaceUtils.sh
 
 if [ ! "$1" ]
 then echo "Usage ./scripts/diagnostics <wireless_interface>"; exit 1


### PR DESCRIPTION
Reverts FluxionNetwork/fluxion#262

The lib path wasn't broken, it was like that by design. Users must launch the diagnostics script from fluxion's root directory.