### PR TITLE
Replace ifconfig with ip commands

### DIFF
--- a/lib/ap/airbase-ng.sh
+++ b/lib/ap/airbase-ng.sh
@@ -19,7 +19,7 @@ function ap_service_stop() {
 
 function ap_service_reset() {
   ap_service_stop
-  
+
   APServiceAccessInterface=""
 
   APServiceChannel=""
@@ -32,15 +32,14 @@ function ap_service_reset() {
 function ap_service_route() {
   local networkSubnet=${APServiceInterfaceAddress%.*}
   local networkAddress=$(( ( ${APServiceInterfaceAddress##*.} + 1 ) % 255 ))
-  
+
   if [ $hostID -eq 0 ]; then
     let hostID++
   fi
-  
+
   # TODO: Dynamically get the airbase-ng tap interface & use below.
   # WARNING: Notice the interface below is STATIC, it'll break eventually!
-  if ! ifconfig "at0" $networkSubnet.$networkAddress \
-    netmask 255.255.255.0; then
+  if ! ip addr add "at0" $networkSubnet.$networkAddress/24; then
     return 1
   fi
 
@@ -51,20 +50,20 @@ function ap_service_route() {
 
 function ap_service_prep() {
   if [ ${#@} -lt 5 ]; then return 1; fi
-  
+
   APServiceInterface=$1
   APServiceInterfaceAddress=$2
   APServiceSSID=$3
   APServiceMAC=$4
   APServiceChannel=$5
-  
+
   ap_service_stop
 
   # Spoof virtual interface MAC address.
   # This is done by airbase-ng automatically.
 
   # airbase-ng uses a monitor-mode virtual interface
-  # and creates a separate interface, atX, for dhcpd.  
+  # and creates a separate interface, atX, for dhcpd.
   APServiceAccessInterface="at0"
 }
 

--- a/lib/ap/hostapd.sh
+++ b/lib/ap/hostapd.sh
@@ -21,13 +21,13 @@ function ap_service_reset() {
   ap_service_stop
 
   # Reset MAC address to original.
-  ifconfig $APServiceInterface down
+  ip link set $APServiceInterface down
   sleep 0.5
 
   macchanger -p $APServiceInterface &> $FLUXIONOutputDevice
   sleep 0.5
 
-  ifconfig $APServiceInterface up
+  ip link set $APServiceInterface up
   sleep 0.5
 
   APServiceAccessInterface=""
@@ -46,13 +46,13 @@ function ap_service_route() {
 
 function ap_service_prep() {
   if [ ${#@} -lt 5 ]; then return 1; fi
-  
+
   APServiceInterface=$1
   APServiceInterfaceAddress=$2
   APServiceSSID=$3
   APServiceMAC=$4
   APServiceChannel=$5
-  
+
   ap_service_stop
 
   # Prepare the hostapd config file.
@@ -64,13 +64,13 @@ channel=$APServiceChannel" \
   > "$APServiceConfigDirectory/$APServiceMAC-hostapd.conf"
 
   # Spoof virtual interface MAC address.
-  ifconfig $APServiceInterface down
+  ip link set $APServiceInterface down
   sleep 0.5
 
   macchanger --mac=$APServiceMAC $APServiceInterface &> $FLUXIONOutputDevice
   sleep 0.5
 
-  ifconfig $APServiceInterface up
+  ip link set $APServiceInterface up
   sleep 0.5
 
   # HostAPD sets the virtual interface mode


### PR DESCRIPTION
I replaced the `ifconfig` calls with `ip link` and `ip addr`.

I see that "route" is listed as an dependency but found no calls to `route` in any scripts. Can someone please verify if it still is necessary?

Also I tested my changes, but just to be sure I'd like someone to review and retest them.

Implements changes for Issue #567.