### PR TITLE
Update hostapd.sh

### DIFF
--- a/lib/ap/hostapd.sh
+++ b/lib/ap/hostapd.sh
@@ -54,13 +54,14 @@ function ap_service_prep() {
   APServiceChannel=$5
   
   ap_service_stop
-
+  if [[ $APServiceChannel <= 11 ]]; then HardwareMode="g"; else HardwareMode="a"; fi
   # Prepare the hostapd config file.
   echo "\
 interface=$APServiceInterface
 driver=nl80211
 ssid=$APServiceSSID
-channel=$APServiceChannel" \
+channel=$APServiceChannel
+hw_mode=$HardwareMode" \
   > "$APServiceConfigDirectory/$APServiceMAC-hostapd.conf"
 
   # Spoof virtual interface MAC address.


### PR DESCRIPTION
We should set the hardware mode based on the channel that is selected. Some cards/chipsets/drivers can accurately guess this, but some can not, by setting it explicitly we broaden the hardware supported.