### PR TITLE
Usage of `egrep` is becoming obselete. Instead opt for using `grep -E`

### DIFF
--- a/attacks/Captive Portal/attack.sh
+++ b/attacks/Captive Portal/attack.sh
@@ -854,7 +854,7 @@ while [ \$AuthenticatorState = \"running\" ]; do
         # Aircrack-ng
         # Check if we've got the correct password by looking for
         # anything other than \"Passphrase not in\" or \"KEY NOT FOUND\".
-        local -r verifiedCondition="aircrack-ng -b $FluxionTargetMAC -w \"$FLUXIONWorkspacePath/candidate.txt\" \"$CaptivePortalHashPath\" | egrep -qi \"Passphrase not in|KEY NOT FOUND\""
+        local -r verifiedCondition="aircrack-ng -b $FluxionTargetMAC -w \"$FLUXIONWorkspacePath/candidate.txt\" \"$CaptivePortalHashPath\" | grep -Eqi \"Passphrase not in|KEY NOT FOUND\""
         ;;
     esac
     echo "

--- a/lib/InterfaceUtils.sh
+++ b/lib/InterfaceUtils.sh
@@ -99,7 +99,7 @@ function interface_hardware() {
   esac
 
   # Check for invalid InterfaceHardwareID (starts or ends with :) .. not a happy face, still won't quote it.
-  if echo "$InterfaceHardwareID" | egrep -q "^:|:$"; then
+  if echo "$InterfaceHardwareID" | grep -Eq "^:|:$"; then
     unset InterfaceHardwareID
     unset InterfaceHardwareBus
     return 2

--- a/lib/installer/InstallerUtils.sh
+++ b/lib/installer/InstallerUtils.sh
@@ -40,9 +40,9 @@ installer_utils_check_version() {
   local -r __installer_utils_check_version__info=$(timeout -s SIGTERM 20 curl "$1" 2>/dev/null)
 
   local -r __installer_utils_check_version__onlineVersion=$(
-    echo "$__installer_utils_check_version__info" | egrep "$2" | egrep -o "[0-9]+")
+    echo "$__installer_utils_check_version__info" | grep -E "$2" | grep -Eo "[0-9]+")
   local -r __installer_utils_check_version__onlineRevision=$(
-    echo "$__installer_utils_check_version__info" | egrep "$3" | egrep -o "[0-9]+")
+    echo "$__installer_utils_check_version__info" | grep -E "$3" | grep -Eo "[0-9]+")
 
   if [ "$__installer_utils_check_version__onlineVersion" ] && \
     [ "$__installer_utils_check_version__onlineRevision" ]; then

--- a/lib/installer/managers/apt.sh
+++ b/lib/installer/managers/apt.sh
@@ -16,7 +16,7 @@ if [ -f "/etc/debian_version" ]; then
   }
 
   prep_package_manager() {
-    if [ ! "$(cat /etc/apt/sources.list | egrep 'deb http://http.kali.org/kali ((kali-rolling|main|contrib|non-free) )*')" ]; then
+    if [ ! "$(cat /etc/apt/sources.list | grep -E 'deb http://http.kali.org/kali ((kali-rolling|main|contrib|non-free) )*')" ]; then
       echo "Adding missing sources to package manager, please wait."
 
       echo "Adding keys.gnupg.net key, please wait."


### PR DESCRIPTION
Since your shell automatically prints STDErr to STDOut for debugging purposes, using `egrep` produces unwanted output to the terminal. Simply replacing `egrep` with `grep -E` fixes this.

Not a major issue in any way, shape or form, but just a small fix.