### PR TITLE
Add band/bus columns, --ap-service/--timeout flags, fix exit hang

### DIFF
--- a/attacks/Handshake Snooper/attack.sh
+++ b/attacks/Handshake Snooper/attack.sh
@@ -476,9 +476,21 @@ attack_targetting_interfaces() {
 }
 
 attack_tracking_interfaces() {
+  # Determine required band from target channel.
+  local __requiredBand=""
+  if [ "$FluxionTargetChannel" ]; then
+    local __ch=$(echo "$FluxionTargetChannel" | grep -oE '[0-9]+' | head -1)
+    if [ -n "$__ch" ] && [ "$__ch" -gt 14 ]; then
+      __requiredBand="5GHz"
+    fi
+  fi
   interface_list_wireless
   local interface
   for interface in "${InterfaceListWireless[@]}"; do
+    if [ "$__requiredBand" ]; then
+      interface_bands "$interface" 2>/dev/null
+      if [[ "${InterfaceBands:-}" != *"$__requiredBand"* ]]; then continue; fi
+    fi
     echo "$interface"
   done
   echo "" # This enables the Skip option.

--- a/lib/HelpUtils.sh
+++ b/lib/HelpUtils.sh
@@ -52,7 +52,7 @@ fluxion_help(){
 
          --list-interfaces
                 List all detected wireless network interfaces with their
-                driver, chipset, bus type, and state, then exit.
+                supported bands, driver, chipset, bus type, and state, then exit.
 
          --interface <iface>
                 Use the specified wireless interface for scanning and
@@ -73,6 +73,18 @@ fluxion_help(){
                 Use the specified wireless interface for the target tracker
                 (channel-change detection). In auto mode the tracker is
                 disabled unless this option is given.
+
+         --ap-service <hostapd|airbase-ng>
+                Override the rogue AP service. Default is hostapd.
+                On DFS channels (52-64, 100-144) auto mode selects
+                airbase-ng automatically since hostapd requires driver
+                radar/CAC support that USB adapters lack.
+
+         --timeout <minutes>
+                Maximum duration in minutes for the attack in auto mode.
+                After this time the attack is stopped and fluxion exits.
+                Default is no timeout (runs indefinitely until the attack
+                succeeds or is interrupted).
 
          -k     Kill interfering wireless processes (NetworkManager, etc.)
                 before allocating interfaces. Implied by --auto.

--- a/lib/ap/airbase-ng.sh
+++ b/lib/ap/airbase-ng.sh
@@ -25,6 +25,15 @@ function ap_service_stop() {
 function ap_service_reset() {
   ap_service_stop
 
+  # Restore original regulatory domain if we changed it.
+  if [ "$APServiceOrigRegDomain" ]; then
+    local __iw=$(command -v iw 2>/dev/null || echo /usr/sbin/iw)
+    if [ -x "$__iw" ]; then
+      "$__iw" reg set "$APServiceOrigRegDomain" 2>/dev/null
+    fi
+    APServiceOrigRegDomain=""
+  fi
+
   APServiceAccessInterface=""
 
   APServiceChannel=""
@@ -38,15 +47,7 @@ function ap_service_route() {
   local networkSubnet=${APServiceInterfaceAddress%.*}
   local networkAddress=$(( ( ${APServiceInterfaceAddress##*.} + 1 ) % 255 ))
 
-  if [ $hostID -eq 0 ]; then
-    let hostID++
-  fi
-
-  # TODO: Dynamically get the airbase-ng tap interface & use below.
-  # WARNING: Notice the interface below is STATIC, it'll break eventuajly!
- if ! ip addr add "$networkSubnet.$networkAddress/24" dev "at0" 2>/dev/null; then
-    return 1
-  fi
+  ip addr add "$networkSubnet.$networkAddress/24" dev "at0" 2>/dev/null
 
   if ! sysctl net.ipv6.conf.at0.disable_ipv6=1 &> $FLUXIONOutputDevice; then
     return 2
@@ -64,6 +65,18 @@ function ap_service_prep() {
 
   ap_service_stop
 
+  # For 5GHz channels, set a permissive regulatory domain to allow
+  # transmission (many adapters default to country 00 which marks
+  # all 5GHz as no-IR/passive-scan only).
+  if [ "$APServiceChannel" -gt 14 ] 2>/dev/null; then
+    local __iw=$(command -v iw 2>/dev/null || echo /usr/sbin/iw)
+    if [ -x "$__iw" ]; then
+      APServiceOrigRegDomain=$("$__iw" reg get 2>/dev/null | grep -m1 "^country" | sed 's/country \([A-Z0-9]*\).*/\1/')
+      "$__iw" reg set BO 2>/dev/null
+      sleep 0.5
+    fi
+  fi
+
   # Spoof virtual interface MAC address.
   # This is done by airbase-ng automatically.
 
@@ -77,14 +90,39 @@ function ap_service_start() {
 
   fluxion_window_open APServiceXtermPID \
     "FLUXION AP Service [airbase-ng]" "$TOP" "#000000" "#FFFFFF" \
-    "airbase-ng -y -e $APServiceSSID -c $APServiceChannel -a $APServiceMAC $APServiceInterface"
+    "airbase-ng -P -e $APServiceSSID -c $APServiceChannel -a $APServiceMAC $APServiceInterface"
 
-  # Wait till airebase-ng starts and creates the extra virtual interface.
+  # Wait till airbase-ng starts and creates the extra virtual interface.
   while [ ! "$APServicePID" ]; do
     sleep 1
     APServicePID=$(pgrep -P $APServiceXtermPID 2>/dev/null)
   done
-  eval ifconfig at0 192.169.254.1
+
+  # Wait for airbase-ng to create the at0 virtual interface.
+  local __retries=0
+  while ! ip link show at0 &>/dev/null; do
+    sleep 1
+    __retries=$((__retries + 1))
+    if [ $__retries -ge 15 ]; then
+      echo "at0 not created after 15s; aborting." > $FLUXIONOutputDevice
+      return 1
+    fi
+  done
+
+  # Bring at0 up — retry in case it needs a moment after creation.
+  __retries=0
+  while ! ip link set at0 up 2>/dev/null || \
+        ! ip link show at0 2>/dev/null | grep -q "UP"; do
+    sleep 1
+    __retries=$((__retries + 1))
+    if [ $__retries -ge 10 ]; then
+      echo "at0 failed to come up after 10s; aborting." > $FLUXIONOutputDevice
+      return 1
+    fi
+  done
+
+  ip addr flush dev at0 2>/dev/null
+  ip addr add "$APServiceInterfaceAddress/24" dev "at0" 2>/dev/null
   ap_service_route
 }
 

--- a/lib/installer/InstallerUtils.sh
+++ b/lib/installer/InstallerUtils.sh
@@ -17,8 +17,8 @@ if ! declare -p InstallerUtilsInstalledPackagesFile >/dev/null 2>&1; then
 fi
 
 # Ensure install-tracking file exists so we can later uninstall only what we added.
-mkdir -p "${InstallerUtilsInstalledPackagesFile%/*}"
-touch "$InstallerUtilsInstalledPackagesFile"
+mkdir -p "${InstallerUtilsInstalledPackagesFile%/*}" 2>/dev/null
+touch "$InstallerUtilsInstalledPackagesFile" 2>/dev/null
 
 # Detect whether a package is already installed for supported package managers.
 installer_utils_package_installed() {

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -22,6 +22,17 @@ for session in $(tmux ls 2>/dev/null | grep -oE '^FLUXION[^:]*'); do
 	tmux kill-session -t "$session" 2>/dev/null && echo "    killed tmux session $session"
 done
 
+echo "[*] Restoring regulatory domain..."
+_iw=$(command -v iw 2>/dev/null || echo /usr/sbin/iw)
+if [ -x "$_iw" ]; then
+	_reg=$("$_iw" reg get 2>/dev/null | grep -m1 "^country" | sed 's/country \([A-Z0-9]*\).*/\1/')
+	if [ "$_reg" = "BO" ]; then
+		"$_iw" reg set 00 2>/dev/null && echo "    regulatory domain reset from BO to 00"
+	else
+		echo "    regulatory domain is $_reg, no change needed"
+	fi
+fi
+
 echo "[*] Restoring wireless interfaces..."
 for iface in $(ip link show | grep -oE 'fluxwl[^ :@]+'); do
 	# Derive original name from MAC: wlx + mac without colons


### PR DESCRIPTION
- Interface dialogs and --list-interfaces now show band (2.4GHz/5GHz) and bus type (usb/pci) columns; band options in scanner filtered to what the selected interface actually supports
- DFS channels (52-64, 100-144) marked with ! in target list
- Add --ap-service flag to override AP service selection
- Add --timeout flag for auto mode (minutes; default infinite)
- Fix exit hang: replace blocking service --status-all with background timeout systemctl try-restart systemd-resolved
- Allow --help and --version without root
- Captive Portal: auto-select airbase-ng on DFS channels; fix deauth-ng.py absolute path; suppress harmless route addr error; abort if ap_service_start fails; pause/resume support
- airbase-ng: two-phase wait for at0 existence then UP state; set permissive regulatory domain for 5GHz channels
- hostapd: set regulatory domain for 5GHz; generate unique config filename per MAC to avoid stale config collisions
- Handshake Snooper: fix jammer interface name from scan list
- InstallerUtils: suppress touch permission error without root
- scripts/cleanup.sh: restore interface name after MAC spoof on cleanup
- Bump revision to 6.21