### PR TITLE
fix: cd into script directory so language menu populates

### DIFF
--- a/fluxion.sh
+++ b/fluxion.sh
@@ -6,6 +6,9 @@
 # Path to directory containing the FLUXION executable script.
 readonly FLUXIONPath=$(dirname $(readlink -f "$0"))
 
+# Always run from the FLUXION directory; relative lookups (e.g. `ls language`) depend on it.
+cd "$FLUXIONPath" || exit 1
+
 # Path to directory containing the FLUXION library (scripts).
 readonly FLUXIONLibPath="$FLUXIONPath/lib"
 

--- a/fluxion.sh
+++ b/fluxion.sh
@@ -3,8 +3,11 @@
 # ============================================================ #
 # ================== < FLUXION Parameters > ================== #
 # ============================================================ #
-# Path to directory containing the FLUXION executable script.
-readonly FLUXIONPath=$(dirname $(readlink -f "$0"))
+# Path to the FLUXION executable script itself, and the directory containing it.
+# Resolved once, up front, so it stays valid after the cd below and after any
+# re-exec that relies on invoking this same script again.
+readonly FLUXIONSelf=$(readlink -f "$0")
+readonly FLUXIONPath=$(dirname "$FLUXIONSelf")
 
 # Always run from the FLUXION directory; relative lookups (e.g. `ls language`) depend on it.
 cd "$FLUXIONPath" || exit 1
@@ -66,7 +69,7 @@ readonly FLUXIONOriginalArgs=$(printf '%q ' "$@")
 if [ ! -t 0 ] && [ -z "$FLUXION_HAS_PTY" ] && [ "$FLUXIONPreParseTMux" ]; then
   export FLUXION_HAS_PTY=1
   exec 3>&1
-  exec script -qc "$0 $FLUXIONOriginalArgs" /dev/null
+  exec script -qc "$FLUXIONSelf $FLUXIONOriginalArgs" /dev/null
 fi
 
 # ===================== < Display Checks > ===================== #
@@ -89,7 +92,7 @@ else
     if [ ! -t 0 ] && [ -z "$FLUXION_HAS_PTY" ]; then
       export FLUXION_HAS_PTY=1
       exec 3>&1
-      exec script -qc "$0 $FLUXIONOriginalArgs" /dev/null
+      exec script -qc "$FLUXIONSelf $FLUXIONOriginalArgs" /dev/null
     fi
   fi
 fi


### PR DESCRIPTION
## Problem

Launching Fluxion from any directory other than its own (e.g. `sudo ~/fluxion/fluxion.sh` from `$HOME`) shows an empty "Select your language" menu with only an `Exit` entry, making the tool unusable without a manual `cd` into the repo first.

## Root cause

`FLUXIONPath` is resolved from `$0` (line 7), but the process never changes into it. `fluxion_set_language()` uses **relative** lookups:

```bash
readarray -t languageCodes < <(ls -1 language | sed -E 's/\.sh//')
...
head -n 3 language/*.sh | ...
```

When the working directory isn't the Fluxion root, `ls -1 language` returns nothing, the language list is empty, and only `Exit` is offered.

## Fix

Add `cd "$FLUXIONPath"` right after path resolution, so every relative lookup resolves correctly regardless of the caller's working directory.

## Related issues

This is the root cause behind several long-standing reports of the empty language menu:

- #621 (`cannot access 'language': No such file or directory`)
- #689 (Language not displayed to select)
- #1071 (Select Your Language its empty)

## Testing

Zorin OS 18 (Ubuntu 24.04), Fluxion 6.30 — before the patch, launching from `$HOME` shows only `Exit`; after the patch, the menu correctly lists all 19 languages regardless of the working directory.
